### PR TITLE
Update README config documentation to use correct keys for testingbot credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ module.exports = function(config) {
 
 ## `testingbot` config properties shared across all browsers
 
-### key
+### apiKey
 Type: `String`
 Default: `process.env.TB_KEY`
 
 Your TestingBot api key, you can sign up [here](https://testingbot.com/users/sign_up).
 
-### secret
+### apiSecret
 Type: `String`
 Default: `process.env.TB_SECRET`
 


### PR DESCRIPTION
At the time of writing, the README says that you can specify your testingbot credentials [with the keys `key` and `secret`](https://github.com/karma-runner/karma-testingbot-launcher/blob/33eb76a29f31a4c437c32f327640c60596170f02/README.md#key). But the [source suggests differently](https://github.com/karma-runner/karma-testingbot-launcher/blob/33eb76a29f31a4c437c32f327640c60596170f02/lib/testingbot_launcher.js#L11-L12), where those config keys need to be `apiKey` and `apiSecret` instead.

In my karma config, specifying my testingbot credentials like so

``` js
module.exports = function(config) {
  testingbot: {
    apiKey: "[key omitted]",
    apiSecret: "[secret omitted]"
  }
}
```

works correctly. Just hoping to correct the docs for the next person who needs these configuration options. Let me know if I missed anything. Thanks!
